### PR TITLE
Use TLS1.2 for pip request, reset SecurityProtocol

### DIFF
--- a/WebKitDev/Functions/Install-Python.ps1
+++ b/WebKitDev/Functions/Install-Python.ps1
@@ -57,9 +57,15 @@ Function Install-Python {
   # Install PIP
   $pipInstall = ('pip=={0}' -f $pipVersion);
   Write-Host ('Installing {0} ...' -f $pipInstall);
+
+  $oldSecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol;
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+
   (New-Object System.Net.WebClient).DownloadFile('https://bootstrap.pypa.io/get-pip.py', 'get-pip.py');
   python get-pip.py $pipInstall;
   Remove-Item get-pip.py -Force;
+
+  [System.Net.ServicePointManager]::SecurityProtocol = $oldSecurityProtocol;
 
   # Install Visual Studio for Python 2.7
   $vcForPythonUrl = 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi';


### PR DESCRIPTION
Have started getting "Could not create SSL/TLS secure channel" errors for getting pip via the script, explicitly ask for TLS1.2 on the request.

This version saves off and restores the SecurityProtocol.